### PR TITLE
Allow for recording offenses on PR, but not failing the build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: Reclaim The Stack - Rubocop
 description: Runs rubocop and posts offences as inline PR comments.
 inputs:
+  failure_exit_code:
+    description: Exit code after running rubocop-- a non-zero exit code will fail the build
+    default: "108"
   github_token:
     description: GITHUB_TOKEN
     default: ${{ github.token }}
@@ -16,5 +19,6 @@ runs:
     - run: ruby $GITHUB_ACTION_PATH/rubocop.rb ${{ inputs.rubocop_arguments }}
       shell: bash
       env:
+        FAILURE_EXIT_CODE: ${{ inputs.failure_exit_code }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         RUBOCOP_GEM_VERSIONS: ${{ inputs.gem_versions }}

--- a/rubocop.rb
+++ b/rubocop.rb
@@ -192,5 +192,5 @@ number_of_offenses = files_with_offenses.sum { |file| file.fetch("offenses").len
 if number_of_offenses > 0
   puts ""
   puts "#{number_of_offenses} offenses found! Failing the build..."
-  exit 108
+  exit ENV.fetch("FAILURE_EXIT_CODE", 108).to_i
 end


### PR DESCRIPTION
This adds a configuration option for specifying the exit code after running rubocop. Previously, when rubocop errors are detected, the exit code was hard-coded to 108. By making this configurable: specifically, setting it to "0" allows for the github build to pass.

@see https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions

This fixes https://github.com/reclaim-the-stack/rubocop-action/issues/6