### PR TITLE
Use bundle install when running via gemfile

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
       - uses: ./
         with:


### PR DESCRIPTION
This allows using more powerful approaches to referencing gems inside Gemfiles, eg. via git: `gem "rubocop-mynewsdesk", git: "https://github.com/mynewsdesk/mnd-rubocop"`